### PR TITLE
Fixed JUnit tests for authenticator

### DIFF
--- a/src/test/java/com/csci3130/daloffline/tests/AuthenticatorTest.java
+++ b/src/test/java/com/csci3130/daloffline/tests/AuthenticatorTest.java
@@ -2,9 +2,11 @@ package com.csci3130.daloffline.tests;
 
 import static org.junit.Assert.*;
 
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+
 import org.junit.Test;
 
-import com.csci3130.daloffline.DalOfflineUI;
 import com.csci3130.daloffline.authentication.*;
 import com.csci3130.daloffline.initialization.DatabaseInitializer;
 
@@ -13,19 +15,15 @@ public class AuthenticatorTest {
 	@Test
 	public void authenticateTest() {
 		
-		String persistenceUnitName = "daloffline_db_testing";
+		EntityManagerFactory factory = Persistence.createEntityManagerFactory("daloffline_db");
 		
-	    DatabaseInitializer.generateUsers(persistenceUnitName);
+	    DatabaseInitializer.generateUsers(factory);
 		
-		assertEquals(true, Authenticator.authenticate("user", "pass"));
-		
-		assertNotEquals(true, Authenticator.authenticate("wrong", "pass"));
-		
-		assertNotEquals(true, Authenticator.authenticate("user", "passssssssssssssss"));
-		
-		assertNotEquals(true, Authenticator.authenticate("", ""));
-		
-		DatabaseInitializer.clearUsers(persistenceUnitName);
+		assertEquals(true, Authenticator.authenticate("user", "pass", factory));
+		assertNotEquals(true, Authenticator.authenticate("wrong", "pass", factory));
+		assertNotEquals(true, Authenticator.authenticate("user", "passssssssssssssss", factory));
+		assertNotEquals(true, Authenticator.authenticate("", "", factory));
+
 		
 	}
 


### PR DESCRIPTION
This test began to fail when we changed how the user generation and authentication worked. It will likely need to be changed again when we stop hard-coding users and associate users to username/password pairs.